### PR TITLE
support popover (suggest element to top layer)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -30,7 +30,7 @@
     border: 1px solid #aaa;
 }
 
-.vue-simple-suggest.designed .suggestions {
+.vue-simple-suggest.designed .suggestions:popover-open {
     top: calc(var(--target-top-bottom) * 1px + 5px);
     left: calc(var(--target-left-left) * 1px);
     right: calc(var(--target-right-righth) * 1px);
@@ -38,7 +38,13 @@
     border: 1px solid #aaa;
     background-color: #fff;
     opacity: 1;
-    z-index: 1000;
+}
+@supports (inset: anchor(bottom)) and (anchor-name: --a) and (position-anchor: --a) {
+    .vue-simple-suggest.designed .suggestions:popover-open {
+        top: calc(anchor(bottom) + 5px);
+        left: anchor(left);
+        right: anchor(right);
+    }
 }
 
 .vue-simple-suggest.designed .suggestions .suggest-item {

--- a/public/style.css
+++ b/public/style.css
@@ -31,11 +31,9 @@
 }
 
 .vue-simple-suggest.designed .suggestions {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 100%;
-    top: calc(100% + 5px);
+    top: calc(var(--target-bottom) * 1px + 5px);
+    left: calc(var(--target-left) * 1px);
+    width: calc(var(--target-width) * 1px);
     border-radius: 3px;
     border: 1px solid #aaa;
     background-color: #fff;

--- a/public/style.css
+++ b/public/style.css
@@ -31,9 +31,9 @@
 }
 
 .vue-simple-suggest.designed .suggestions {
-    top: calc(var(--target-bottom) * 1px + 5px);
-    left: calc(var(--target-left) * 1px);
-    width: calc(var(--target-width) * 1px);
+    top: calc(var(--target-top-bottom) * 1px + 5px);
+    left: calc(var(--target-left-left) * 1px);
+    right: calc(var(--target-right-righth) * 1px);
     border-radius: 3px;
     border: 1px solid #aaa;
     background-color: #fff;

--- a/src/app.vue
+++ b/src/app.vue
@@ -46,6 +46,8 @@ export default {
 </script>
 
 <style>
+@import url("../dist/style.css");
+/** @import url("../public/style.css") */
 .mainWrapper {
   width: 70vw;
   margin-left: auto;

--- a/src/vue-simple-suggest.vue
+++ b/src/vue-simple-suggest.vue
@@ -21,6 +21,7 @@
         popover="manual"
         v-if="!!listShown && !removeList" :id="listId" class="suggestions" role="listbox"
         :aria-labelledby="listId" :class="styles.suggestions"
+        :style="withPositionAnchor"
       >
         <li v-if="!!$slots['misc-item-above']" :class="styles.miscItemAbove">
           <slot name="misc-item-above" :suggestions="suggestions" :query="text" />
@@ -46,6 +47,8 @@
 
 <script>
 import { defaultControls, modes, isOn, hasKeyCodeByCode, hasKeyCode, getPropertyByAttribute } from './utils.js'
+
+const supportsAnchor = CSS.supports("(inset: anchor(bottom)) and (anchor-name: --a) and (position-anchor: --a)");
 
 export default {
   name: 'VueSimpleSuggest',
@@ -89,6 +92,9 @@ export default {
       controlScheme: {},
       listId: `${this.$.uid}-suggestions`,
       popoverStyle: undefined,
+      popoverAbort: undefined,
+      anchorName: `--popover-${this.$.uid}`,
+      withPositionAnchor: supportsAnchor ? `position-anchor: --popover-${this.$.uid}` : undefined
     };
   },
   computed: {
@@ -225,6 +231,9 @@ export default {
         this.inputElement.setAttribute('aria-activedescendant', '')
         this.inputElement.setAttribute('aria-autocomplete', 'list')
         this.inputElement.setAttribute('aria-controls', this.listId)
+        if (supportsAnchor && "anchorName" in this.inputElement.style) {
+          this.inputElement.style.anchorName = this.anchorName;
+        }
       }
     },
     isScopedSlotEmpty (slot) {
@@ -597,7 +606,11 @@ export default {
     async showPopover (el) {
       const opened = el.matches(':popover-open');
       if (opened) return;
-      this.setPopoverPositionStyle();
+      this.popoverAbort?.();
+      const controller = new AbortController();
+      this.popoverAbort = controller.abort.bind(controller);
+      const signal = controller.signal;
+      this.registerParentEvents(this.inputElement, signal);
       this.$nextTick(() => {
         el.showPopover();
       })
@@ -605,6 +618,7 @@ export default {
     async hidePopover (el) {
       const opened = el.matches(':popover-open');
       if (!opened) return;
+      this.popoverAbort?.();
       el.hidePopover();
     },
     setPopoverPositionStyle () {
@@ -633,6 +647,24 @@ export default {
         }
       }
       this.popoverStyle = pos;
+    },
+    registerParentEvents(el, signal) {
+      if (supportsAnchor) return;
+      this.setPopoverPositionStyle();
+      const setPopoverPositionStyle = this.setPopoverPositionStyle.bind(this);
+      window.addEventListener("resize",setPopoverPositionStyle, { capture: true, passive: true, signal })
+      // scroll イベントの登録
+      while (el) {
+        const style = globalThis.getComputedStyle(el);
+        const overflowX = style.overflowX;
+        const overflowY = style.overflowY;
+        // スクロールが表示できる 且つ コンテンツが スクロールするサイズ の判定
+        const canScroll = overflowIsScroll.has(overflowY) || overflowIsScroll.has(overflowX);
+        // スクロールが必要そうなら イベントを監視する
+        if (canScroll) el.addEventListener("scroll", setPopoverPositionStyle, { capture: true, passive: true, signal });
+        el = el.offsetParent;
+      }
+      window.addEventListener("scroll", setPopoverPositionStyle, { capture: true, passive: true, signal });
     }
   }
 }

--- a/src/vue-simple-suggest.vue
+++ b/src/vue-simple-suggest.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vue-simple-suggest" :class="[ styles.vueSimpleSuggest, { designed: !destyled, focus: isInFocus } ]" @keydown.tab="isTabbed = true">
+  <div class="vue-simple-suggest" :class="[ styles.vueSimpleSuggest, { designed: !destyled, focus: isInFocus } ]" @keydown.tab="isTabbed = true" :style="popoverStyled">
     <div
       ref="inputSlot" class="input-wrapper" role="combobox" aria-haspopup="listbox"
       :aria-owns="listId" :aria-expanded="!!listShown && !removeList ? 'true' : 'false'" :class="styles.inputWrapper"
@@ -16,8 +16,9 @@
         </template>
       </Suspense>
     </div>
-    <transition name="vue-simple-suggest">
+    <transition name="vue-simple-suggest" @before-enter="el => showPopover(el)" @after-leave="hidePopover">
       <ul
+        popover="manual"
         v-if="!!listShown && !removeList" :id="listId" class="suggestions" role="listbox"
         :aria-labelledby="listId" :class="styles.suggestions"
       >
@@ -86,8 +87,9 @@ export default {
       isFalseFocus: false,
       isTabbed: false,
       controlScheme: {},
-      listId: `${this.$.uid}-suggestions`
-    }
+      listId: `${this.$.uid}-suggestions`,
+      popoverStyle: { top: 0, left: 0, right: 0, bottom: 0, height: 0, width: 0 }
+    };
   },
   computed: {
     listIsRequest () {
@@ -132,6 +134,17 @@ export default {
         onKeydown: this.onKeyDown,
         onKeyup: this.onListKeyUp
       })
+    },
+    popoverStyled () {
+      const { top, bottom, left, right, height, width } = this.popoverStyle;
+      return {
+        [`--target-top`]: top,
+        [`--target-bottom`]: bottom,
+        [`--target-left`]: left,
+        [`--target-right`]: right,
+        [`--target-height`]: height,
+        [`--target-width`]: width,
+      };
     }
   },
   watch: {
@@ -578,6 +591,27 @@ export default {
     },
     filterDefault (item, query) {
       return query ? this.displayProperty(item).toLowerCase().indexOf(query.toLowerCase()) > -1 : true
+    },
+    async showPopover (el) {
+      const opened = el.matches(':popover-open');
+      if (opened) return;
+      this.setPopoverPositionStyle();
+      this.$nextTick(() => {
+        el.showPopover();
+      })
+    },
+    async hidePopover (el) {
+      const opened = el.matches(':popover-open');
+      if (!opened) return;
+      el.hidePopover();
+    },
+    setPopoverPositionStyle () {
+      const input = this.inputElement;
+      let pos = { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
+      if (input) {
+        pos = input.getBoundingClientRect();
+      }
+      this.popoverStyle = pos;
     }
   }
 }

--- a/src/vue-simple-suggest.vue
+++ b/src/vue-simple-suggest.vue
@@ -88,7 +88,7 @@ export default {
       isTabbed: false,
       controlScheme: {},
       listId: `${this.$.uid}-suggestions`,
-      popoverStyle: { top: 0, left: 0, right: 0, bottom: 0, height: 0, width: 0 }
+      popoverStyle: undefined,
     };
   },
   computed: {
@@ -136,14 +136,16 @@ export default {
       })
     },
     popoverStyled () {
-      const { top, bottom, left, right, height, width } = this.popoverStyle;
+      const style = this.popoverStyle;
       return {
-        [`--target-top`]: top,
-        [`--target-bottom`]: bottom,
-        [`--target-left`]: left,
-        [`--target-right`]: right,
-        [`--target-height`]: height,
-        [`--target-width`]: width,
+        [`--target-top-top`]: style?.top.top,
+        [`--target-top-bottom`]: style?.top.bottom,
+        [`--target-bottom-top`]: style?.bottom.top,
+        [`--target-bottom-bottom`]: style?.bottom.bottom,
+        [`--target-left-left`]: style?.left.left,
+        [`--target-left-right`]: style?.left.right,
+        [`--target-right-left`]: style?.right.left,
+        [`--target-right-right`]: style?.right.right,
       };
     }
   },
@@ -607,9 +609,28 @@ export default {
     },
     setPopoverPositionStyle () {
       const input = this.inputElement;
-      let pos = { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
+      let pos = undefined;
       if (input) {
-        pos = input.getBoundingClientRect();
+        const { height, width } = document.documentElement.getBoundingClientRect();
+        const rect = input.getBoundingClientRect();
+        pos = {
+          left: {
+            left: rect.left,
+            right: rect.right,
+          },
+          top: {
+            top: rect.top,
+            bottom: rect.bottom,
+          },
+          right: {
+            left: width - rect.left,
+            right: width - rect.right,
+          },
+          bottom: {
+            top: height - rect.top,
+            bottom: height - rect.bottom,
+          },
+        }
       }
       this.popoverStyle = pos;
     }


### PR DESCRIPTION
### Summary

This PR updates the suggest element to use the native `popover` attribute,
allowing it to be rendered in the browser's **top layer**.

---

### Motivation

Currently, the suggestion dropdown is rendered within the normal DOM flow.
In certain layouts this can cause:

- Clipping due to `overflow: hidden`
- z-index conflicts
- Stacking context issues

Rendering the suggest element in the top layer via the native Popover API
resolves these layout limitations without introducing any external dependency.

---

### Implementation Details

- The suggest element now uses the native `popover` attribute
- `showPopover()` / `hidePopover()` are triggered via the existing visibility logic
- No external dependencies were introduced
- The overall component structure and API remain unchanged
- The diff was intentionally kept minimal

---

### Behavior Change

The dropdown is now rendered in the browser's **top layer** instead of the
normal stacking context.

This improves behavior in complex layouts (e.g. inside containers with
`overflow: hidden` or complex stacking contexts).

The **public API and usage remain unchanged**, so existing integrations
should continue to work without modification.

---

### Notes

If preferred, this behavior could also be made configurable, but the current
implementation keeps the change minimal and dependency-free.